### PR TITLE
Setup CI on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: node_js
+install:
+  - npm install -g bower web-component-tester
+  - bower install
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+script:
+  - wct


### PR DESCRIPTION
Uses xvfb to run headless Firefox - the only browser available on Travis. Easier than setting up Sauce Labs.

Here's the latest build from my clone: https://travis-ci.org/crhym3/beacon-send/builds/67121380

Closes #6